### PR TITLE
[#11] fix : 서브페이지 브라우저 세로 리사이징 시 버그

### DIFF
--- a/src/js/setPreviewImage.js
+++ b/src/js/setPreviewImage.js
@@ -6,13 +6,13 @@ function init(){
     function setPreviewImage(){
         var previewHeight = parseInt($imgPreview.css('height'));
         var scale = previewHeight / imgDomHeight;
-        console.log('test');
-
         $mkImgDom.css({'transform' : 'scale(' + scale + ')'});
     }
     
     $(window).load(setPreviewImage);
-    $(window).on('resize', setPreviewImage);
+    $(window).on('resize', function(){
+        setTimeout(setPreviewImage, 500);
+    });
 }
 
 init();


### PR DESCRIPTION
세로로 브라우저 리사이징 할 경우 `transition`이 걸려있어서,
제대로 setPreviewImage함수가 제대로 동장하지 않음
setTimeout 메서드를 사용하여 해결

Resolves #11